### PR TITLE
Add bindings option

### DIFF
--- a/recipes-devtools/mraa/mraa.inc
+++ b/recipes-devtools/mraa/mraa.inc
@@ -35,7 +35,7 @@ FILES_${PN}-java = "${libdir}/libmraajava.so \
                     ${libdir}/.debug/libmraajava.so \
                    "
 
-RDEPENDS_${PN}-java += "java-runtime"
+RDEPENDS_${PN}-java += "java2-runtime"
 INSANE_SKIP_${PN}-java = "debug-files"
 
 

--- a/recipes-devtools/mraa/mraa.inc
+++ b/recipes-devtools/mraa/mraa.inc
@@ -9,7 +9,14 @@ S = "${WORKDIR}/git"
 
 inherit distutils-base pkgconfig python-dir cmake
 
-PACKAGES =+ "python-${PN} node-${PN} ${PN}-java"
+# override this in local.conf to get a subset of bindings.
+# BINDINGS_pn-mraa="python"
+# will result in only the python bindings being built/packaged.
+BINDINGS ?= "python nodejs java"
+
+PACKAGES =+ "${@bb.utils.contains('BINDINGS', 'java', '${PN}-java', '', d)}"
+PACKAGES =+ "${@bb.utils.contains('BINDINGS', 'nodejs', 'node-${PN}', '', d)}"
+PACKAGES =+ "${@bb.utils.contains('BINDINGS', 'python', 'python-${PN}', '', d)}"
 
 # python-mraa package containing Python bindings
 FILES_python-${PN} = "${PYTHON_SITEPACKAGES_DIR}/ \
@@ -35,13 +42,18 @@ FILES_${PN}-java = "${libdir}/libmraajava.so \
                     ${libdir}/.debug/libmraajava.so \
                    "
 
-RDEPENDS_${PN}-java += "java2-runtime"
+RDEPENDS_${PN}-java += "${@bb.utils.contains('PACKAGES', '${PN}-java', 'java2-runtime', '', d)}"
 INSANE_SKIP_${PN}-java = "debug-files"
 
 
 FILES_${PN}-doc += "${datadir}/mraa/examples/"
 
-PACKAGECONFIG ??= "python nodejs java"
+PACKAGECONFIG ??= "${@bb.utils.contains('PACKAGES', 'node-${PN}', 'nodejs', '', d)} \
+ ${@bb.utils.contains('PACKAGES', 'python-${PN}', 'python', '', d)} \
+ ${@bb.utils.contains('PACKAGES', '${PN}-java', 'java', '', d)}"
+
+
+
 PACKAGECONFIG[python] = "-DBUILDSWIGPYTHON=ON, -DBUILDSWIGPYTHON=OFF, swig-native python,"
 PACKAGECONFIG[nodejs] = "-DBUILDSWIGNODE=ON, -DBUILDSWIGNODE=OFF, swig-native nodejs,"
 PACKAGECONFIG[java] = "-DBUILDSWIGJAVA=ON, -DBUILDSWIGJAVA=OFF, swig-native icedtea7-native,"

--- a/recipes-devtools/upm/upm_0.6.1.bb
+++ b/recipes-devtools/upm/upm_0.6.1.bb
@@ -41,7 +41,7 @@ FILES_${PN}-java = "${libdir}/libjava*.so \
                     ${prefix}/src/debug/${BPN}/${PV}-${PR}/build/src/*/*javaupm_* \
                     ${libdir}/.debug/libjava*.so \
                    "
-RDEPENDS_${PN}-java += "java-runtime mraa-java"
+RDEPENDS_${PN}-java += "java2-runtime mraa-java"
 INSANE_SKIP_${PN}-java = "debug-files"
 
 
@@ -64,4 +64,3 @@ set (JAVA_INCLUDE_PATH2 ${JAVA_HOME}/include/linux CACHE PATH \"java include pat
 set (JAVA_JVM_LIBRARY ${JAVA_HOME}/jre/lib/amd64/libjvm.so CACHE FILEPATH \"path to JVM\" FORCE)
 " >> ${WORKDIR}/toolchain.cmake
 }
-


### PR DESCRIPTION
This does 2 things:
1) Adds BINDINGS variable.  This way you can put in your local.conf something like: 
BINDINGS_pn-mraa="java nodejs"  
and just get the nodejs and java bindings built rather than all of them.  
BINDINGS_pn-mraa=""
will just give you the C library.
2) updated the runttime to java2-runtime.  To pick one of the available ones put in local.conf:
PREFERRED_PROVIDER_virtual/java2-runtime = "openjdk-7-jre"
BINDINGS_pn-mraa="java"
There are several options:
NOTE: multiple providers are available for runtime java2-runtime (cacao, openjre-8, jamvm, openjdk-7-jre, openjdk-8)
