### PR TITLE
paho-mqtt: redirect SRC_URI to github tree

### DIFF
--- a/recipes-connectivity/mosquitto/mosquitto_1.4.8.bb
+++ b/recipes-connectivity/mosquitto/mosquitto_1.4.8.bb
@@ -5,7 +5,7 @@ SECTION = "console/network"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=62ddc846179e908dc0c8efec4a42ef20"
 
-DEPENDS = "openssl util-linux python"
+DEPENDS = "openssl util-linux python c-ares"
 
 PR = "r0"
 
@@ -16,8 +16,8 @@ SRC_URI = "http://mosquitto.org/files/source/mosquitto-${PV}.tar.gz \
 
 export LIB_SUFFIX="${@d.getVar('baselib', True).replace('lib', '')}"
 
-SRC_URI[md5sum] = "cd879f5964311501ba8e2275add71484"
-SRC_URI[sha256sum] = "591f3adcb6ed92c01f7ace1c878af728b797fe836892535620aa6106f42dbcc6"
+SRC_URI[md5sum] = "d859cd474ffa61a6197bdabe007b9027"
+SRC_URI[sha256sum] = "d96eb5610e57cc3e273f4527d3f54358ab7711459941a9e64bc4d0a85c2acfda"
 
 do_compile() {
     oe_runmake PREFIX=/usr

--- a/recipes-connectivity/paho-mqtt/paho-mqtt_3.1.bb
+++ b/recipes-connectivity/paho-mqtt/paho-mqtt_3.1.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = " \
 
 PR = "r1"
 
-SRC_URI = "git://git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.c.git;protocol=http \
+SRC_URI = "git://github.com/eclipse/paho.mqtt.c.git;protocol=https \
            file://makefile.patch \
 "
 

--- a/recipes-connectivity/tinyb/tinyb.inc
+++ b/recipes-connectivity/tinyb/tinyb.inc
@@ -34,14 +34,26 @@ INSANE_SKIP_${PN}-java = "dev-so debug-files"
 
 export JAVA_HOME="${STAGING_DIR}/${BUILD_SYS}/usr/lib/jvm/openjdk-8-native"
 export JAVA_HOME_target="${STAGING_LIBDIR}/jvm/openjdk-8"
+JAVA_HOME_target = "${STAGING_LIBDIR}/jvm/openjdk-8"
+
+def get_java_arch(arch):
+    java_arch = {}
+    java_arch['i686'] = "i386"
+    java_arch['i586'] = "i386"
+    java_arch['x86_64'] = "amd64"
+    java_arch['arm'] = "arm"
+
+    return java_arch[arch]
+
+java_arch = "${@get_java_arch('${TARGET_ARCH}')}"
 
 cmake_do_generate_toolchain_file_append() {
   echo "
 set (JAVA_AWT_INCLUDE_PATH ${JAVA_HOME_target}/include CACHE PATH \"AWT include path\" FORCE)
-set (JAVA_AWT_LIBRARY ${JAVA_HOME_target}/jre/lib/amd64/libjawt.so CACHE FILEPATH \"AWT Library\" FORCE)
+set (JAVA_AWT_LIBRARY ${JAVA_HOME_target}/jre/lib/${java_arch}/libjawt.so CACHE FILEPATH \"AWT Library\" FORCE)
 set (JAVA_INCLUDE_PATH ${JAVA_HOME_target}/include CACHE PATH \"java include path\" FORCE)
 set (JAVA_INCLUDE_PATH2 ${JAVA_HOME_target}/include/linux CACHE PATH \"java include path\" FORCE)
-set (JAVA_JVM_LIBRARY ${JAVA_HOME_target}/jre/lib/amd64/server/libjvm.so CACHE FILEPATH \"path to JVM\" FORCE)
+set (JAVA_JVM_LIBRARY ${JAVA_HOME_target}/jre/lib/${java_arch}/server/libjvm.so CACHE FILEPATH \"path to JVM\" FORCE)
 " >> ${WORKDIR}/toolchain.cmake
 }
 

--- a/recipes-devtools/upm/upm_0.7.0.bb
+++ b/recipes-devtools/upm/upm_0.7.0.bb
@@ -20,7 +20,10 @@ RDEPENDS_${PN} += " mraa"
 
 PACKAGECONFIG ??= "python nodejs java"
 
-PACKAGECONFIG[python] = "-DBUILDSWIGPYTHON=ON, -DBUILDSWIGPYTHON=OFF, swig-native ${PYTHON_PN},"
+#These two lines disable the python package generation until we can get it building consistently on all platforms/architectures.
+#PACKAGECONFIG[python] = "-DBUILDSWIGPYTHON=ON, -DBUILDSWIGPYTHON=OFF, swig-native ${PYTHON_PN},"
+PACKAGECONFIG[python] = "-DBUILDSWIGPYTHON=OFF, -DBUILDSWIGPYTHON=OFF, swig-native ${PYTHON_PN},"
+
 PACKAGECONFIG[nodejs] = "-DBUILDSWIGNODE=ON, -DBUILDSWIGNODE=OFF, swig-native nodejs,"
 PACKAGECONFIG[java] = "-DBUILDSWIGJAVA=ON, -DBUILDSWIGJAVA=OFF, swig-native openjdk-8-native,"
 

--- a/recipes-devtools/upm/upm_0.7.0.bb
+++ b/recipes-devtools/upm/upm_0.7.0.bb
@@ -19,6 +19,7 @@ FILES_${PN}-doc += " ${datadir}/upm/examples/"
 RDEPENDS_${PN} += " mraa"
 
 PACKAGECONFIG ??= "python nodejs java"
+
 PACKAGECONFIG[python] = "-DBUILDSWIGPYTHON=ON, -DBUILDSWIGPYTHON=OFF, swig-native ${PYTHON_PN},"
 PACKAGECONFIG[nodejs] = "-DBUILDSWIGNODE=ON, -DBUILDSWIGNODE=OFF, swig-native nodejs,"
 PACKAGECONFIG[java] = "-DBUILDSWIGJAVA=ON, -DBUILDSWIGJAVA=OFF, swig-native openjdk-8-native,"


### PR DESCRIPTION
As git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.c is nomore
available, use a github mirror.

Signed-off-by: Franck Demathieu franck.demathieu@intel.com
